### PR TITLE
Drop Microsoft.SourceLink.GitHub reference

### DIFF
--- a/VatValidation/VatValidation.csproj
+++ b/VatValidation/VatValidation.csproj
@@ -27,7 +27,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.5" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="*" PrivateAssets="All"/>
     <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.0" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
   </ItemGroup>
 


### PR DESCRIPTION
This should be enabled by default in NET 8+ SDK
https://github.com/dotnet/sourcelink?tab=readme-ov-file#using-source-link-in-net-projects
