### PR TITLE
Default implementation of Valid(VatNumber) which calls Valid(ReadOnlySpan<int>)

### DIFF
--- a/VatValidation/Countries/BE.cs
+++ b/VatValidation/Countries/BE.cs
@@ -19,8 +19,6 @@ public class BE : CountryBase
 	private BE() { }
 	public static ICountry Instance { get; } = new BE();
 
-	public override bool Valid(VatNumber vat) => Valid(vat.GetIntsIfNoChars());
-
 	public override int MinLength => 9;
 
 	public override string FormatStripped(VatNumber vat) => ToStr(FixLen(vat.GetInts()));
@@ -32,7 +30,7 @@ public class BE : CountryBase
 	private static bool ValidFormat(ReadOnlySpan<int> d) => d.Length == 9 || (d.Length == 10 && (d[0] == 0 || d[1] == 1));
 
 	// https://www.fiducial.be/nl/news/Hoe-kunt-u-weten-of-uw-klant-u-een-correct-BTW-nummer-gaf
-	internal static bool Valid(ReadOnlySpan<int> digits) =>
+	protected override bool Valid(ReadOnlySpan<int> digits) =>
 		ValidFormat(digits) && (
 		Convert.ToInt32(ToStr(digits[..^2])) +
 		Convert.ToInt32(ToStr(digits[^2..]))) % 97 == 0;

--- a/VatValidation/Countries/DK.cs
+++ b/VatValidation/Countries/DK.cs
@@ -24,8 +24,6 @@ public class DK : CountryBase
 	private DK() { }
 	public static ICountry Instance { get; } = new DK();
 
-	public override bool Valid(VatNumber vat) => Valid(vat.GetIntsIfNoChars());
-
 	public override int MinLength => 8;
 
 	public override string FormatNational(VatNumber vat) => Format(vat, Valid, d => $"{ToStr(d[0..2])} {ToStr(d[2..4])} {ToStr(d[4..6])} {ToStr(d[6..8])}");
@@ -34,7 +32,7 @@ public class DK : CountryBase
 
 	// https://da.wikipedia.org/wiki/Det_Centrale_Virksomhedsregister
 	// https://datacvr.virk.dk/
-	internal static bool Valid(ReadOnlySpan<int> digits) => Valid(digits.ToArray());
+	protected override bool Valid(ReadOnlySpan<int> digits) => Valid(digits.ToArray());
 	internal static bool Valid(int[] digits) => digits.Length == 8 &&
 		(digits
 		.Zip(_multipliers, (d, m) => d * m)

--- a/VatValidation/Countries/EE.cs
+++ b/VatValidation/Countries/EE.cs
@@ -24,8 +24,6 @@ public class EE : CountryBase
 	private EE() { }
 	public static ICountry Instance { get; } = new EE();
 
-	public override bool Valid(VatNumber vat) => Valid(vat.GetIntsIfNoChars());
-
 	public override int MinLength => 9;
 
 	public override string FormatNational(VatNumber vat) => Format(vat, Valid, ToStr);
@@ -37,7 +35,7 @@ public class EE : CountryBase
 	private static bool ValidFormat(ReadOnlySpan<int> d) => d.Length == 9 && d[0] == 1 && d[1] == 0;
 
 	/// <summary>Kaibemaksukohuslase (KMKR)</summary>
-	internal static bool Valid(ReadOnlySpan<int> digits) => ValidFormat(digits) && Valid(digits.ToArray());
+	protected override bool Valid(ReadOnlySpan<int> digits) => ValidFormat(digits) && Valid(digits.ToArray());
 	private static bool Valid(int[] digits) =>
 		(10 - digits
 		.Zip(_multipliers, (d, m) => d * m)

--- a/VatValidation/Countries/ES.cs
+++ b/VatValidation/Countries/ES.cs
@@ -15,6 +15,7 @@ public class ES : CountryBase
 	public static ICountry Instance { get; } = new ES();
 
 	public override bool Valid(VatNumber vat) => Valid((string?)vat ?? string.Empty);
+	protected override bool Valid(ReadOnlySpan<int> digits) => false;
 
 	public override int MinLength => 9;
 

--- a/VatValidation/Countries/FI.cs
+++ b/VatValidation/Countries/FI.cs
@@ -21,8 +21,6 @@ public class FI : CountryBase
 	private FI() { }
 	public static ICountry Instance { get; } = new FI();
 
-	public override bool Valid(VatNumber vat) => Valid(vat.GetIntsIfNoChars());
-
 	public override int MinLength => 8;
 
 	public override string FormatNational(VatNumber vat) => Format(vat, Valid, d => $"{ToStr(d[0..7])}-{ToStr(d[7..])}");
@@ -30,7 +28,7 @@ public class FI : CountryBase
 	private static readonly int[] _multipliers = [7, 9, 10, 5, 8, 4, 2, 1];
 
 	/// <summary>http://www.finlex.fi/sv/laki/ajantasa/2001/20010288</summary>
-	internal static bool Valid(ReadOnlySpan<int> digits) => Valid(digits.ToArray());
+	protected override bool Valid(ReadOnlySpan<int> digits) => Valid(digits.ToArray());
 	internal static bool Valid(int[] digits) => digits.Length == 8 &&
 		(11 - digits
 		.Zip(_multipliers, (d, m) => d * m)

--- a/VatValidation/Countries/LT.cs
+++ b/VatValidation/Countries/LT.cs
@@ -21,8 +21,6 @@ public class LT : CountryBase
 	private LT() { }
 	public static ICountry Instance { get; } = new LT();
 
-	public override bool Valid(VatNumber vat) => Valid(vat.GetIntsIfNoChars());
-
 	public override int MinLength => 9;
 
 	public override string FormatNational(VatNumber vat) => Format(vat, Valid, ToStr);
@@ -34,7 +32,7 @@ public class LT : CountryBase
 		(d.Length == 12 && d[10] == 1);
 
 	private static int SumMod11(int[] d, int idxWeightOffset) => d.Select((v, i) => v * ((i + idxWeightOffset) % 9 + 1)).Sum() % 11;
-	private static bool Valid(ReadOnlySpan<int> digits)
+	protected override bool Valid(ReadOnlySpan<int> digits)
 	{
 		if (!ValidFormat(digits))
 			return false;

--- a/VatValidation/Countries/LV.cs
+++ b/VatValidation/Countries/LV.cs
@@ -19,8 +19,6 @@ public class LV : CountryBase
 	private LV() { }
 	public static ICountry Instance { get; } = new LV();
 
-	public override bool Valid(VatNumber vat) => Valid(vat.GetIntsIfNoChars());
-
 	public override int MinLength => 11;
 
 	public override string FormatNational(VatNumber vat) => Format(vat, Valid, ToStr);
@@ -31,7 +29,7 @@ public class LV : CountryBase
 
 	private static bool ValidFormat(ReadOnlySpan<int> d) => d.Length == 11 && d[0] > 3;
 
-	internal static bool Valid(ReadOnlySpan<int> digits) => ValidFormat(digits) && Valid(digits.ToArray());
+	protected override bool Valid(ReadOnlySpan<int> digits) => ValidFormat(digits) && Valid(digits.ToArray());
 	private static bool Valid(int[] digits) => digits
 		.Zip(_multipliers, (d, m) => d * m)
 		.Sum() % 11 == 3;

--- a/VatValidation/Countries/NL.cs
+++ b/VatValidation/Countries/NL.cs
@@ -25,6 +25,7 @@ public class NL : CountryBase
 	public static ICountry Instance { get; } = new NL();
 
 	public override bool Valid(VatNumber vat) => Valid(BtwStripp((string?)vat ?? string.Empty));
+	protected override bool Valid(ReadOnlySpan<int> digits) => false;
 
 	public override int MinLength => 12;
 

--- a/VatValidation/Countries/NO.cs
+++ b/VatValidation/Countries/NO.cs
@@ -24,8 +24,6 @@ public class NO : CountryBase
 	private NO() { }
 	public static ICountry Instance { get; } = new NO();
 
-	public override bool Valid(VatNumber vat) => Valid(vat.GetIntsIfNoChars());
-
 	public override int MinLength => 9;
 
 	public override string FormatNational(VatNumber vat) => Format(vat, Valid, d => $"{ToStr(d[0..3])} {ToStr(d[3..6])} {ToStr(d[6..9])}");
@@ -38,7 +36,7 @@ public class NO : CountryBase
 	private static bool ValidFormat(ReadOnlySpan<int> d) => d.Length == 9 && (
 		d[0] == 2 || d[0] == 3 ||
 		d[0] == 8 || d[0] == 9);
-	internal static bool Valid(ReadOnlySpan<int> digits) => ValidFormat(digits) && Valid(digits.ToArray());
+	protected override bool Valid(ReadOnlySpan<int> digits) => ValidFormat(digits) && Valid(digits.ToArray());
 	private static bool Valid(int[] digits) =>
 		(11 - digits
 		.Zip(_multipliers, (d, m) => d * m)

--- a/VatValidation/Countries/PT.cs
+++ b/VatValidation/Countries/PT.cs
@@ -23,8 +23,6 @@ public class PT : CountryBase
 	private PT() { }
 	public static ICountry Instance { get; } = new PT();
 
-	public override bool Valid(VatNumber vat) => Valid(vat.GetIntsIfNoChars());
-
 	public override int MinLength => 9;
 
 	public override string FormatNational(VatNumber vat) => Format(vat, Valid, ToStr);
@@ -36,7 +34,7 @@ public class PT : CountryBase
 	private static bool ValidFormat(ReadOnlySpan<int> d) => d.Length == 9 && d[0] != 0;
 
 	// https://pt.wikipedia.org/wiki/N%C3%BAmero_de_identifica%C3%A7%C3%A3o_fiscal
-	internal static bool Valid(ReadOnlySpan<int> digits) => ValidFormat(digits) && Valid(digits.ToArray());
+	protected override bool Valid(ReadOnlySpan<int> digits) => ValidFormat(digits) && Valid(digits.ToArray());
 	private static bool Valid(int[] digits)
 	{
 		int digitoVerificacao = 11 - (digits

--- a/VatValidation/Countries/SE.cs
+++ b/VatValidation/Countries/SE.cs
@@ -25,9 +25,7 @@ public class SE : CountryBase
 	private SE() { }
 	public static ICountry Instance { get; } = new SE();
 
-	public override bool Valid(VatNumber vat) => Valid(vat.GetIntsIfNoChars());
-
-	internal static bool Valid(ReadOnlySpan<int> digits) => digits.Length == 10 && LuhnSum(digits) == 0;
+	protected override bool Valid(ReadOnlySpan<int> digits) => digits.Length == 10 && LuhnSum(digits) == 0;
 
 	public override int MinLength => 10;
 	public override int MinLengthVat => 14;

--- a/VatValidation/Countries/_Base.cs
+++ b/VatValidation/Countries/_Base.cs
@@ -5,7 +5,12 @@ namespace VatValidation.Countries;
 public abstract class CountryBase : ICountry
 {
 	/// <summary>Validate VAT number for Country</summary>
-	public abstract bool Valid(VatNumber vat);
+	public virtual bool Valid(VatNumber vat) => Valid(vat.GetIntsIfNoChars());
+	/// <summary>
+	/// Most are numeric only so default implementation is supplied above
+	/// If not used or unsupported, and <see cref="Valid(VatNumber)"/> is overriden instead, this can be false
+	/// </summary>
+	protected abstract bool Valid(ReadOnlySpan<int> digits);
 
 	public virtual string FormatStripped(VatNumber vat) => ToStr(vat.GetInts());
 


### PR DESCRIPTION
This is the most common case so simplifys most implementations. For implementations like ES, NL where this isn't the case we keep the old one and just add

    protected override bool Valid(ReadOnlySpan<int> digits) => false;

instead.