### PR TITLE
Add FormatVatStripped with strict behavior and updated tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,8 @@
 * `VatNumber` structure
 * `TryParse` (some numbers can match multiple countries and not return, try with countrycode first)
 * `FormatStripped` for unique key in database (use together with CountryCode)
+* `FormatNational` readable format of national number
+* `FormatVat` readable format of VAT number
+* `FormatVatStripped` stripped to minimal VAT representation for data (format not yet finall)
 
 Countries still work in progress

--- a/VatValidation.Tests/TestcasesFromXmlComments.cs
+++ b/VatValidation.Tests/TestcasesFromXmlComments.cs
@@ -118,6 +118,10 @@ public class TestcasesFromXmlComments
 			Assert.Equal(data.ExpectedNational, vat.FormatNational);
 			Assert.Equal(data.ExpectedVat, vat.FormatVat);
 			Assert.Equal(data.ExpectedStripped, vat.FormatStripped);
+			if (data.ExpectedVatStripped is not null)
+			{
+				Assert.Equal(data.ExpectedVatStripped, vat.FormatVatStripped);
+			}
 		};
 
 		yield return () => // VatStripValidNational
@@ -131,9 +135,16 @@ public class TestcasesFromXmlComments
 			// Formatted if valid, otherwise original data
 			if (!vatStrip.Valid)
 				Assert.Equal(data.ExpectedStripped, vatStrip.FormatNational);
-			//Assert.Equal(vatStrip.Valid ? expectNational : expectedStriped, vatStrip.FormatNational);
 			Assert.Equal(vatStrip.Valid ? data.ExpectedNational : data.ExpectedStripped, vatStrip.FormatNational);
-			Assert.Equal(data.ExpectedVatStripped ?? data.ExpectedVat, vatStrip.FormatVat);
+			if (vatStrip.Valid)
+			{
+				// make sure stripped but Valid VatNumber always formats fully
+				Assert.Equal(data.ExpectedVat, vatStrip.FormatVat);
+			}
+			if (data.ExpectedVatStripped is not null)
+			{
+				Assert.Equal(data.ExpectedVatStripped, vatStrip.FormatVatStripped);
+			}
 		};
 
 		if (!string.IsNullOrEmpty(data.ExpectedVat))
@@ -211,7 +222,7 @@ public class TestcasesFromXmlComments
 	}
 
 	[Theory]
-	[InlineData("SE", "invalid, in: 1, national: 1, vat: SE 1 01, stripped: 1, vatstripped: SE 1 01")] // dummy to not leave this empty
+	[InlineData("SE", "invalid, in: 1, national: 1, vat: SE 1 01, stripped: 1, vatstripped: SE101")] // dummy to not leave this empty
 	public void RunManualXmlDocumentationLineTest(string ccKey, string line)
 	{
 		var data = new TestData(line);

--- a/VatValidation/Countries/BE.cs
+++ b/VatValidation/Countries/BE.cs
@@ -4,15 +4,15 @@ namespace VatValidation.Countries;
 // tests of non leading zero dosnt play well with <testcases>, left in legacy testcases
 /// <country>Belgium</country>
 /// <testcases>
-/// valid, in: 0566.988.259, national: 0566.988.259, stripped: 0566988259, vat: BE 0566988259, vatstripped: BE 0566988259, dontTryParse, comment: Also matching SE
-/// valid, in: 0566988259, national: 0566.988.259, stripped: 0566988259, vat: BE 0566988259, vatstripped: BE 0566988259, dontTryParse, comment: Also matching SE
-/// valid, in: 0427.155.930, national: 0427.155.930, stripped: 0427155930, vat: BE 0427155930, vatstripped: BE 0427155930
-/// valid, in: 0427155930, national: 0427.155.930, stripped: 0427155930, vat: BE 0427155930, vatstripped: BE 0427155930
-/// invalid, in: 0566988258, national: 0566988258, stripped: 0566988258, vat: BE 0566988258, vatstripped: BE 0566988258
-/// valid, in: BE 0566988259, national: 0566.988.259, stripped: 0566988259, vat: BE 0566988259, vatstripped: BE 0566988259
-/// valid, in: BE0566988259, national: 0566.988.259, stripped: 0566988259, vat: BE 0566988259, vatstripped: BE 0566988259
-/// valid, in: BE0427155930, national: 0427.155.930, stripped: 0427155930, vat: BE 0427155930, vatstripped: BE 0427155930
-/// invalid, in: BE0566988258, national: BE0566988258, stripped: 0566988258, vat: BE 0566988258, vatstripped: BE 0566988258
+/// valid, in: 0566.988.259, national: 0566.988.259, stripped: 0566988259, vat: BE 0566988259, vatstripped: BE0566988259, dontTryParse, comment: Also matching SE
+/// valid, in: 0566988259, national: 0566.988.259, stripped: 0566988259, vat: BE 0566988259, vatstripped: BE0566988259, dontTryParse, comment: Also matching SE
+/// valid, in: 0427.155.930, national: 0427.155.930, stripped: 0427155930, vat: BE 0427155930, vatstripped: BE0427155930
+/// valid, in: 0427155930, national: 0427.155.930, stripped: 0427155930, vat: BE 0427155930, vatstripped: BE0427155930
+/// invalid, in: 0566988258, national: 0566988258, stripped: 0566988258, vat: BE 0566988258, vatstripped: BE0566988258
+/// valid, in: BE 0566988259, national: 0566.988.259, stripped: 0566988259, vat: BE 0566988259, vatstripped: BE0566988259
+/// valid, in: BE0566988259, national: 0566.988.259, stripped: 0566988259, vat: BE 0566988259, vatstripped: BE0566988259
+/// valid, in: BE0427155930, national: 0427.155.930, stripped: 0427155930, vat: BE 0427155930, vatstripped: BE0427155930
+/// invalid, in: BE0566988258, national: BE0566988258, stripped: 0566988258, vat: BE 0566988258, vatstripped: BE0566988258
 /// </testcases>
 public class BE : CountryBase
 {

--- a/VatValidation/Countries/DK.cs
+++ b/VatValidation/Countries/DK.cs
@@ -4,20 +4,20 @@ namespace VatValidation.Countries;
 /// <country>Denmark</country>
 /// <testcases>
 /// valid, in: 25313763, national: 25 31 37 63, vat: DK 25313763, stripped: 25313763
-/// valid, in: 25 31 37 63, national: 25 31 37 63, vat: DK 25313763, stripped: 25313763, vatstripped: DK 25313763
-/// valid, in: 29403473, national: 29 40 34 73, vat: DK 29403473, stripped: 29403473, vatstripped: DK 29403473
-/// invalid, in: 29403473x, strippedvalid, national: 29 40 34 73, vat: DK 29403473, stripped: 29403473, vatstripped: DK 29403473
-/// invalid, in: 05 31 37 63, national: 05 31 37 63, vat: DK 05313763, stripped: 05313763, vatstripped: DK 05313763
-/// invalid, in: 05313763, national: 05313763, vat: DK 05313763, stripped: 05313763, vatstripped: DK 05313763
-/// invalid, in: 25 31 37 60, national: 25 31 37 60, vat: DK 25313760, stripped: 25313760, vatstripped: DK 25313760
-/// invalid, in: 25313760, national: 25313760, vat: DK 25313760, stripped: 25313760, vatstripped: DK 25313760
+/// valid, in: 25 31 37 63, national: 25 31 37 63, vat: DK 25313763, stripped: 25313763, vatstripped: DK25313763
+/// valid, in: 29403473, national: 29 40 34 73, vat: DK 29403473, stripped: 29403473, vatstripped: DK29403473
+/// invalid, in: 29403473x, strippedvalid, national: 29 40 34 73, vat: DK 29403473, stripped: 29403473, vatstripped: DK29403473
+/// invalid, in: 05 31 37 63, national: 05 31 37 63, vat: DK 05313763, stripped: 05313763, vatstripped: DK05313763
+/// invalid, in: 05313763, national: 05313763, vat: DK 05313763, stripped: 05313763, vatstripped: DK05313763
+/// invalid, in: 25 31 37 60, national: 25 31 37 60, vat: DK 25313760, stripped: 25313760, vatstripped: DK25313760
+/// invalid, in: 25313760, national: 25313760, vat: DK 25313760, stripped: 25313760, vatstripped: DK25313760
 /// valid, in: DK 25313763, national: 25 31 37 63, vat: DK 25313763, stripped: 25313763
 /// valid, in: DK 25 31 37 63, national: 25 31 37 63, vat: DK 25313763, stripped: 25313763
-/// valid, in: DK25313763, national: 25 31 37 63, vat: DK 25313763, stripped: 25313763, vatstripped: DK 25313763
+/// valid, in: DK25313763, national: 25 31 37 63, vat: DK 25313763, stripped: 25313763, vatstripped: DK25313763
 /// valid, in: 25313763, national: 25 31 37 63, vat: DK 25313763, stripped: 25313763
-/// valid, in: DK 29 40 34 73, national: 29 40 34 73, vat: DK 29403473, stripped: 29403473, vatstripped: DK 29403473
-/// invalid, in: DK 25313762, national: DK 25313762, vat: DK 25313762, stripped: 25313762, vatstripped: DK 25313762
-/// invalid, in: DK 25 31 37 62, national: DK 25 31 37 62, vat: DK 25313762, stripped: 25313762, vatstripped: DK 25313762
+/// valid, in: DK 29 40 34 73, national: 29 40 34 73, vat: DK 29403473, stripped: 29403473, vatstripped: DK29403473
+/// invalid, in: DK 25313762, national: DK 25313762, vat: DK 25313762, stripped: 25313762, vatstripped: DK25313762
+/// invalid, in: DK 25 31 37 62, national: DK 25 31 37 62, vat: DK 25313762, stripped: 25313762, vatstripped: DK25313762
 /// </testcases>
 public class DK : CountryBase
 {

--- a/VatValidation/Countries/EE.cs
+++ b/VatValidation/Countries/EE.cs
@@ -3,20 +3,20 @@ namespace VatValidation.Countries;
 
 /// <country>Estonia</country>
 /// <testcases>
-/// valid, in: 100931558, national: 100931558, vat: EE 100931558, stripped: 100931558, vatstripped: EE 100931558
-/// valid, in: 100 931 558, national: 100931558, vat: EE 100931558, stripped: 100931558, vatstripped: EE 100931558
+/// valid, in: 100931558, national: 100931558, vat: EE 100931558, stripped: 100931558, vatstripped: EE100931558
+/// valid, in: 100 931 558, national: 100931558, vat: EE 100931558, stripped: 100931558, vatstripped: EE100931558
 /// valid, in: 100594102, national: 100594102, vat: EE 100594102, stripped: 100594102, comment: matches both EE and NO
 /// invalid, in: 100 594 102x, strippedvalid, national: 100594102, vat: EE 100594102, stripped: 100594102
-/// invalid, in: 100594103, national: 100594103, vat: EE 100594103, stripped: 100594103, vatstripped: EE 100594103
-/// invalid, in: 999999999, national: 999999999, vat: EE 999999999, stripped: 999999999, vatstripped: EE 999999999, dontTryParse
-/// invalid, in: 999 999 999, national: 999 999 999, vat: EE 999 999 999, stripped: 999999999, vatstripped: EE 999999999, dontTryParse
-/// invalid, in: 999 999 99, national: 999 999 99, vat: EE 999 999 99, stripped: 99999999, vatstripped: EE 99999999
-/// invalid, in: 99999999, national: 99999999, vat: EE 99999999, stripped: 99999999, vatstripped: EE 99999999
-/// invalid, in: 099999999, national: 099999999, vat: EE 099999999, stripped: 099999999, vatstripped: EE 099999999
-/// valid, in: EE100931558, national: 100931558, vat: EE 100931558, stripped: 100931558, vatstripped: EE 100931558
-/// valid, in: EE 100 931 558, national: 100931558, vat: EE 100931558, stripped: 100931558, vatstripped: EE 100931558
-/// invalid, in: EE 999 999 999, national: EE 999 999 999, vat: EE EE 999 999 999, stripped: 999999999, vatstripped: EE 999999999
-/// invalid, in: EE999999999, national: EE999999999, vat: EE EE999999999, stripped: 999999999, vatstripped: EE 999999999
+/// invalid, in: 100594103, national: 100594103, vat: EE 100594103, stripped: 100594103, vatstripped: EE100594103
+/// invalid, in: 999999999, national: 999999999, vat: EE 999999999, stripped: 999999999, vatstripped: EE999999999, dontTryParse
+/// invalid, in: 999 999 999, national: 999 999 999, vat: EE 999 999 999, stripped: 999999999, vatstripped: EE999999999, dontTryParse
+/// invalid, in: 999 999 99, national: 999 999 99, vat: EE 999 999 99, stripped: 99999999, vatstripped: EE99999999
+/// invalid, in: 99999999, national: 99999999, vat: EE 99999999, stripped: 99999999, vatstripped: EE99999999
+/// invalid, in: 099999999, national: 099999999, vat: EE 099999999, stripped: 099999999, vatstripped: EE099999999
+/// valid, in: EE100931558, national: 100931558, vat: EE 100931558, stripped: 100931558, vatstripped: EE100931558
+/// valid, in: EE 100 931 558, national: 100931558, vat: EE 100931558, stripped: 100931558, vatstripped: EE100931558
+/// invalid, in: EE 999 999 999, national: EE 999 999 999, vat: EE EE 999 999 999, stripped: 999999999, vatstripped: EE999999999
+/// invalid, in: EE999999999, national: EE999999999, vat: EE EE999999999, stripped: 999999999, vatstripped: EE999999999
 /// valid, in: EE 100594102, national: 100594102, vat: EE 100594102, stripped: 100594102
 /// </testcases>
 public class EE : CountryBase

--- a/VatValidation/Countries/ES.cs
+++ b/VatValidation/Countries/ES.cs
@@ -5,9 +5,9 @@ namespace VatValidation.Countries;
 /// <testcases>
 /// valid, in: A58818501, national: A58818501, vat: ES A58818501, stripped: A58818501
 /// invalid, in: A58818502, national: A58818502, vat: ES A58818502, stripped: A58818502
-/// invalid, in: A5881850x, national: A5881850x, vat: ES A5881850x, stripped: A5881850, vatstripped: ES A5881850
-/// valid, in: B12345674, national: B12345674, vat: ES B12345674, stripped: B12345674
-/// valid, in: S1454158E, national: S1454158E, vat: ES S1454158E, stripped: S1454158E
+/// invalid, in: A5881850x, national: A5881850x, vat: ES A5881850x, stripped: A5881850, vatstripped: ESA5881850
+/// valid, in: B12345674, national: B12345674, vat: ES B12345674, stripped: B12345674, vatstripped: ESB12345674
+/// valid, in: S1454158E, national: S1454158E, vat: ES S1454158E, stripped: S1454158E, vatstripped: ESS1454158E
 /// </testcases>
 public class ES : CountryBase
 {

--- a/VatValidation/Countries/FI.cs
+++ b/VatValidation/Countries/FI.cs
@@ -3,18 +3,18 @@ namespace VatValidation.Countries;
 
 /// <country>Finland</country>
 /// <testcases>
-/// valid, in: 02017244, national: 0201724-4, vat: FI 02017244, stripped: 02017244, vatstripped: FI 02017244
-/// valid, in: 0201724-4, national: 0201724-4, vat: FI 02017244, stripped: 02017244, vatstripped: FI 02017244
-/// invalid, in: 02017244x, strippedvalid, national: 0201724-4, vat: FI 02017244, stripped: 02017244, vatstripped: FI 02017244
-/// invalid, in: 0201723-4, national: 0201723-4, vat: FI 02017234, stripped: 02017234, vatstripped: FI 02017234
-/// invalid, in: 02017234, national: 02017234, vat: FI 02017234, stripped: 02017234, vatstripped: FI 02017234
-/// invalid, in: 201723-4, national: 201723-4, vat: FI 2017234, stripped: 2017234, vatstripped: FI 2017234
-/// invalid, in: 2017234, national: 2017234, vat: FI 2017234, stripped: 2017234, vatstripped: FI 2017234
-/// valid, in: FI 0201724-4, national: 0201724-4, vat: FI 02017244, stripped: 02017244, vatstripped: FI 02017244
-/// valid, in: FI 02017244, national: 0201724-4, vat: FI 02017244, stripped: 02017244, vatstripped: FI 02017244
-/// valid, in: FI02017244, national: 0201724-4, vat: FI 02017244, stripped: 02017244, vatstripped: FI 02017244
-/// invalid, in: FI 0201723-4, national: FI 0201723-4, vat: FI 02017234, stripped: 02017234, vatstripped: FI 02017234
-/// invalid, in: FI 02017234, national: FI 02017234, vat: FI 02017234, stripped: 02017234, vatstripped: FI 02017234
+/// valid, in: 02017244, national: 0201724-4, vat: FI 02017244, stripped: 02017244, vatstripped: FI02017244
+/// valid, in: 0201724-4, national: 0201724-4, vat: FI 02017244, stripped: 02017244, vatstripped: FI02017244
+/// invalid, in: 02017244x, strippedvalid, national: 0201724-4, vat: FI 02017244, stripped: 02017244, vatstripped: FI02017244
+/// invalid, in: 0201723-4, national: 0201723-4, vat: FI 02017234, stripped: 02017234, vatstripped: FI02017234
+/// invalid, in: 02017234, national: 02017234, vat: FI 02017234, stripped: 02017234, vatstripped: FI02017234
+/// invalid, in: 201723-4, national: 201723-4, vat: FI 2017234, stripped: 2017234, vatstripped: FI2017234
+/// invalid, in: 2017234, national: 2017234, vat: FI 2017234, stripped: 2017234, vatstripped: FI2017234
+/// valid, in: FI 0201724-4, national: 0201724-4, vat: FI 02017244, stripped: 02017244, vatstripped: FI02017244
+/// valid, in: FI 02017244, national: 0201724-4, vat: FI 02017244, stripped: 02017244, vatstripped: FI02017244
+/// valid, in: FI02017244, national: 0201724-4, vat: FI 02017244, stripped: 02017244, vatstripped: FI02017244
+/// invalid, in: FI 0201723-4, national: FI 0201723-4, vat: FI 02017234, stripped: 02017234, vatstripped: FI02017234
+/// invalid, in: FI 02017234, national: FI 02017234, vat: FI 02017234, stripped: 02017234, vatstripped: FI02017234
 /// </testcases>
 public class FI : CountryBase
 {

--- a/VatValidation/Countries/ICountry.cs
+++ b/VatValidation/Countries/ICountry.cs
@@ -7,5 +7,6 @@ public interface ICountry
 	string FormatStripped(VatNumber vat);
 	string FormatNational(VatNumber vat);
 	string FormatVat(VatNumber vat);
+	string FormatVatStripped(VatNumber vat);
 	bool TryParse(string input, out VatNumber vat);
 }

--- a/VatValidation/Countries/LT.cs
+++ b/VatValidation/Countries/LT.cs
@@ -8,7 +8,7 @@ namespace VatValidation.Countries;
 /// <checksum>mod 11</checksum>
 /// <status>No official source</status>
 /// <testcases>
-/// valid, in: 119511515, national: 119511515, vat: LT119511515, stripped: 119511515
+/// valid, in: 119511515, national: 119511515, vat: LT119511515, stripped: 119511515, vatstripped: LT119511515
 /// valid, in: 100001919017, national: 100001919017, vat: LT100001919017, stripped: 100001919017
 /// valid, in: 241102419, national: 241102419, vat: LT241102419, stripped: 241102419
 /// valid, in: LT633 878 716, national: 633878716, vat: LT633878716, stripped: 633878716

--- a/VatValidation/Countries/LV.cs
+++ b/VatValidation/Countries/LV.cs
@@ -8,7 +8,7 @@ namespace VatValidation.Countries;
 /// <checksum>mod 11</checksum>
 /// <status>No official source</status>
 /// <testcases>
-/// valid, in: 40003521600, national: 40003521600, vat: LV40003521600, stripped: 40003521600
+/// valid, in: 40003521600, national: 40003521600, vat: LV40003521600, stripped: 40003521600, vatstripped: LV40003521600
 /// valid, in: LV 4000 3521 600, national: 40003521600, vat: LV40003521600, stripped: 40003521600
 /// invalid, in: 40003521601, national: 40003521601, vat: LV40003521601, stripped: 40003521601
 /// invalid, in: 4000352160, national: 4000352160, vat: LV4000352160, stripped: 4000352160

--- a/VatValidation/Countries/NL.cs
+++ b/VatValidation/Countries/NL.cs
@@ -33,6 +33,7 @@ public class NL : CountryBase
 	public override string FormatNational(VatNumber vat) => Valid(BtwStripp(vat)) ? FormatVat(vat) : (string?)vat ?? string.Empty;
 
 	public override string FormatVat(VatNumber vat) => FormatStrippedVat(FormatStripped(vat));
+	public override string FormatVatStripped(VatNumber vat) => FormatVat(vat);
 	private string FormatStrippedVat(string stripped) => BtwFormatValid(stripped) ? $"{CC}{stripped}" : "";
 
 	private const string charset = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ+*";

--- a/VatValidation/Countries/NO.cs
+++ b/VatValidation/Countries/NO.cs
@@ -3,17 +3,17 @@ namespace VatValidation.Countries;
 
 /// <country>Norway</country>
 /// <testcases>
-/// valid, in: 977074010, national: 977 074 010, vat: NO 977 074 010, stripped: 977074010
+/// valid, in: 977074010, national: 977 074 010, vat: NO 977 074 010, stripped: 977074010, vatstripped: NO977074010
 /// valid, in: 977 074 010, national: 977 074 010, vat: NO 977 074 010, stripped: 977074010
 /// invalid, in: 977 074 010x, strippedvalid, national: 977 074 010, vat: NO 977 074 010, stripped: 977074010
-/// invalid, in: 977074011, national: 977074011, vat: NO 977074011, stripped: 977074011, vatstripped: NO 977074011
-/// invalid, in: 977 074 011, national: 977 074 011, vat: NO 977 074 011, stripped: 977074011, vatstripped: NO 977074011
+/// invalid, in: 977074011, national: 977074011, vat: NO 977074011, stripped: 977074011, vatstripped: NO977074011
+/// invalid, in: 977 074 011, national: 977 074 011, vat: NO 977 074 011, stripped: 977074011, vatstripped: NO977074011
 /// invalid, in: 977 074 01, national: 977 074 01, vat: , stripped: 97707401, vatstripped:
 /// invalid, in: 97707401, national: 97707401, vat: , stripped: 97707401, vatstripped:
 /// invalid, in: 777074016, national: 777074016, vat: , stripped: 777074016, vatstripped:
-/// valid, in: 977 074 010MVA, national: 977 074 010, vat: NO 977 074 010, stripped: 977074010, vatstripped: NO 977 074 010
-/// valid, in: NO 977 074 010MVA, national: 977 074 010, vat: NO 977 074 010, stripped: 977074010, vatstripped: NO 977 074 010
-/// valid, in: NO977074010, national: 977 074 010, vat: NO 977 074 010, stripped: 977074010, vatstripped: NO 977 074 010
+/// valid, in: 977 074 010MVA, national: 977 074 010, vat: NO 977 074 010, stripped: 977074010, vatstripped: NO977074010
+/// valid, in: NO 977 074 010MVA, national: 977 074 010, vat: NO 977 074 010, stripped: 977074010, vatstripped: NO977074010
+/// valid, in: NO977074010, national: 977 074 010, vat: NO 977 074 010, stripped: 977074010, vatstripped: NO977074010
 /// valid, in: 310033243, national: 310 033 243, vat: NO 310 033 243, stripped: 310033243, comment: test number from skatteetaten.no
 /// invalid, in: 310033242, national: 310033242, vat: NO 310033242, stripped: 310033242
 /// valid, in: 212409472, national: 212 409 472, vat: NO 212 409 472, stripped: 212409472, comment: test number from skatteetaten.no
@@ -29,6 +29,7 @@ public class NO : CountryBase
 	public override string FormatNational(VatNumber vat) => Format(vat, Valid, d => $"{ToStr(d[0..3])} {ToStr(d[3..6])} {ToStr(d[6..9])}");
 
 	public override string FormatVat(VatNumber vat) => ValidFormat(vat.GetInts().ToArray()) ? $"{CC} {FormatNational(vat)}" : "";
+	public override string FormatVatStripped(VatNumber vat) => ValidFormat(vat.GetInts().ToArray()) ? $"{CC}{FormatStripped(vat)}" : "";
 
 	private static readonly int[] _multipliers = [3, 2, 7, 6, 5, 4, 3, 2, 1];
 

--- a/VatValidation/Countries/PT.cs
+++ b/VatValidation/Countries/PT.cs
@@ -3,20 +3,20 @@ namespace VatValidation.Countries;
 
 /// <country>Portugal</country>
 /// <testcases>
-/// valid, in: 999999990, national: 999999990, stripped: 999999990, vat: PT 999999990, vatstripped: PT 999999990
-/// valid, in: 287024008, national: 287024008, stripped: 287024008, vat: PT 287024008, vatstripped: PT 287024008
-/// valid, in: 287 024 008, national: 287024008, stripped: 287024008, vat: PT 287024008, vatstripped: PT 287024008
-/// valid, in: 501442600, national: 501442600, stripped: 501442600, vat: PT 501442600, vatstripped: PT 501442600
-/// invalid, in: 999999999, national: 999999999, stripped: 999999999, vat: PT 999999999, vatstripped: PT 999999999, dontTryParse
-/// invalid, in: 999 999 999, national: 999 999 999, stripped: 999999999, vat: PT 999 999 999, vatstripped: PT 999999999, dontTryParse
-/// invalid, in: 999 999 99, national: 999 999 99, stripped: 99999999, vat: PT 999 999 99, vatstripped: PT 99999999
-/// invalid, in: 099999999, national: 099999999, stripped: 099999999, vat: PT 099999999, vatstripped: PT 099999999
-/// valid, in: PT 999999990, national: 999999990, stripped: 999999990, vat: PT 999999990, vatstripped: PT 999999990
-/// valid, in: PT 999 999 990, national: 999999990, stripped: 999999990, vat: PT 999999990, vatstripped: PT 999999990
-/// valid, in: PT999999990, national: 999999990, stripped: 999999990, vat: PT 999999990, vatstripped: PT 999999990
-/// valid, in: PT 287024008, national: 287024008, stripped: 287024008, vat: PT 287024008, vatstripped: PT 287024008
-/// valid, in: PT 501442600, national: 501442600, stripped: 501442600, vat: PT 501442600, vatstripped: PT 501442600
-/// invalid, in: PT 999 999 999, national: PT 999 999 999, stripped: 999999999, vat: PT PT 999 999 999, vatstripped: PT 999999999
+/// valid, in: 999999990, national: 999999990, stripped: 999999990, vat: PT 999999990, vatstripped: PT999999990
+/// valid, in: 287024008, national: 287024008, stripped: 287024008, vat: PT 287024008, vatstripped: PT287024008
+/// valid, in: 287 024 008, national: 287024008, stripped: 287024008, vat: PT 287024008, vatstripped: PT287024008
+/// valid, in: 501442600, national: 501442600, stripped: 501442600, vat: PT 501442600, vatstripped: PT501442600
+/// invalid, in: 999999999, national: 999999999, stripped: 999999999, vat: PT 999999999, vatstripped: PT999999999, dontTryParse
+/// invalid, in: 999 999 999, national: 999 999 999, stripped: 999999999, vat: PT 999 999 999, vatstripped: PT999999999, dontTryParse
+/// invalid, in: 999 999 99, national: 999 999 99, stripped: 99999999, vat: PT 999 999 99, vatstripped: PT99999999
+/// invalid, in: 099999999, national: 099999999, stripped: 099999999, vat: PT 099999999, vatstripped: PT099999999
+/// valid, in: PT 999999990, national: 999999990, stripped: 999999990, vat: PT 999999990, vatstripped: PT999999990
+/// valid, in: PT 999 999 990, national: 999999990, stripped: 999999990, vat: PT 999999990, vatstripped: PT999999990
+/// valid, in: PT999999990, national: 999999990, stripped: 999999990, vat: PT 999999990, vatstripped: PT999999990
+/// valid, in: PT 287024008, national: 287024008, stripped: 287024008, vat: PT 287024008, vatstripped: PT287024008
+/// valid, in: PT 501442600, national: 501442600, stripped: 501442600, vat: PT 501442600, vatstripped: PT501442600
+/// invalid, in: PT 999 999 999, national: PT 999 999 999, stripped: 999999999, vat: PT PT 999 999 999, vatstripped: PT999999999
 /// </testcases>
 public class PT : CountryBase
 {

--- a/VatValidation/Countries/SE.cs
+++ b/VatValidation/Countries/SE.cs
@@ -3,22 +3,22 @@ namespace VatValidation.Countries;
 
 /// <country>Sweden</country>
 /// <testcases>
-/// valid, in: 1010101010, national: 101010-1010, vat: SE 1010101010 01, stripped: 1010101010, vatstripped: SE 1010101010 01
-/// valid, in: 5566778899, national: 556677-8899, vat: SE 5566778899 01, stripped: 5566778899, vatstripped: SE 5566778899 01
-/// valid, in: 556677-8899, national: 556677-8899, vat: SE 5566778899 01, stripped: 5566778899, vatstripped: SE 5566778899 01
-/// invalid, in: 556677-8899x, strippedvalid, national: 556677-8899, vat: SE 5566778899 01, stripped: 5566778899, vatstripped: SE 5566778899 01
-/// invalid, in: 5566778890, national: 5566778890, vat: SE 5566778890 01, stripped: 5566778890, vatstripped: SE 5566778890 01
-/// invalid, in: 556677-8890, national: 556677-8890, vat: SE 5566778890 01, stripped: 5566778890, vatstripped: SE 5566778890 01
-/// invalid, in: 55667788, national: 55667788, vat: SE 55667788 01, stripped: 55667788, vatstripped: SE 55667788 01
-/// valid, in: SE 556677-8899, national: 556677-8899, vat: SE 5566778899 01, stripped: 5566778899, vatstripped: SE 5566778899 01
-/// valid, in: SE556677-8899, national: 556677-8899, vat: SE 5566778899 01, stripped: 5566778899, vatstripped: SE 5566778899 01
-/// valid, in: SE 5566778899, national: 556677-8899, vat: SE 5566778899 01, stripped: 5566778899, vatstripped: SE 5566778899 01
-/// valid, in: SE5566778899, national: 556677-8899, vat: SE 5566778899 01, stripped: 5566778899, vatstripped: SE 5566778899 01
-/// valid, in: SE 556677-8501, national: 556677-8501, vat: SE 5566778501 01, stripped: 5566778501, vatstripped: SE 5566778501 01
-/// valid, in: 5566778501, national: 556677-8501, vat: SE 5566778501 01, stripped: 5566778501, vatstripped: SE 5566778501 01
-/// invalid, in: 5566778898, national: 5566778898, vat: SE 5566778898 01, stripped: 5566778898, vatstripped: SE 5566778898 01
-/// valid, in: 0566988259, national: 056698-8259, vat: SE 0566988259 01, stripped: 0566988259, vatstripped: SE 0566988259 01, dontTryParse, comment: BE number
-/// invalid, in: 566988259, national: 566988259, vat: SE 566988259 01, stripped: 566988259, vatstripped: SE 566988259 01, comment: BE number and also matches NO
+/// valid, in: 1010101010, national: 101010-1010, vat: SE 1010101010 01, stripped: 1010101010, vatstripped: SE101010101001
+/// valid, in: 5566778899, national: 556677-8899, vat: SE 5566778899 01, stripped: 5566778899, vatstripped: SE556677889901
+/// valid, in: 556677-8899, national: 556677-8899, vat: SE 5566778899 01, stripped: 5566778899, vatstripped: SE556677889901
+/// invalid, in: 556677-8899x, strippedvalid, national: 556677-8899, vat: SE 5566778899 01, stripped: 5566778899, vatstripped: SE556677889901
+/// invalid, in: 5566778890, national: 5566778890, vat: SE 5566778890 01, stripped: 5566778890, vatstripped: SE556677889001
+/// invalid, in: 556677-8890, national: 556677-8890, vat: SE 5566778890 01, stripped: 5566778890, vatstripped: SE556677889001
+/// invalid, in: 55667788, national: 55667788, vat: SE 55667788 01, stripped: 55667788, vatstripped: SE5566778801
+/// valid, in: SE 556677-8899, national: 556677-8899, vat: SE 5566778899 01, stripped: 5566778899, vatstripped: SE556677889901
+/// valid, in: SE556677-8899, national: 556677-8899, vat: SE 5566778899 01, stripped: 5566778899, vatstripped: SE556677889901
+/// valid, in: SE 5566778899, national: 556677-8899, vat: SE 5566778899 01, stripped: 5566778899, vatstripped: SE556677889901
+/// valid, in: SE5566778899, national: 556677-8899, vat: SE 5566778899 01, stripped: 5566778899, vatstripped: SE556677889901
+/// valid, in: SE 556677-8501, national: 556677-8501, vat: SE 5566778501 01, stripped: 5566778501, vatstripped: SE556677850101
+/// valid, in: 5566778501, national: 556677-8501, vat: SE 5566778501 01, stripped: 5566778501, vatstripped: SE556677850101
+/// invalid, in: 5566778898, national: 5566778898, vat: SE 5566778898 01, stripped: 5566778898, vatstripped: SE556677889801
+/// valid, in: 0566988259, national: 056698-8259, vat: SE 0566988259 01, stripped: 0566988259, vatstripped: SE056698825901, dontTryParse, comment: BE number
+/// invalid, in: 566988259, national: 566988259, vat: SE 566988259 01, stripped: 566988259, vatstripped: SE56698825901, comment: BE number and also matches NO
 /// </testcases>
 public class SE : CountryBase
 {
@@ -33,6 +33,7 @@ public class SE : CountryBase
 	public override string FormatNational(VatNumber vat) => Format(vat, Valid, d => $"{ToStr(d[0..6])}-{ToStr(d[6..])}");
 
 	public override string FormatVat(VatNumber vat) => $"{CC} {FormatStripped(vat)} 01";
+	public override string FormatVatStripped(VatNumber vat) => $"{CC}{FormatStripped(vat)}01";
 
 	protected override string GetVatInner(string input)
 	{

--- a/VatValidation/Countries/_Base.cs
+++ b/VatValidation/Countries/_Base.cs
@@ -18,6 +18,8 @@ public abstract class CountryBase : ICountry
 
 	public virtual string FormatVat(VatNumber vat) => $"{CC} {FormatStripped(vat)}";
 
+	public virtual string FormatVatStripped(VatNumber vat) => $"{CC}{FormatStripped(vat)}";
+
 	private string? _ccCache;
 	public virtual string CC => _ccCache ??= string.Intern(GetType().Name);
 	public abstract int MinLength { get; }

--- a/VatValidation/VatNumber.cs
+++ b/VatValidation/VatNumber.cs
@@ -24,6 +24,7 @@ public readonly struct VatNumber(string vatNumber) : IEquatable<VatNumber>
 	public string FormatNational => _country?.FormatNational(this) ?? _vatNumber;
 
 	public string FormatVat => _country?.FormatVat(this) ?? _vatNumber;
+	public string FormatVatStripped => _country?.FormatVatStripped(this) ?? _vatNumber;
 
 	public VatNumber VatStripped => _country is null ? new(FormatStripped) : new(_country, FormatStripped);
 


### PR DESCRIPTION
With some new countries it has become clear that we need Formatted and Striped versions of VAT

VatStripped.FormatVat has since before, for invalid numbers possibly changed format, it still does but now that behavior is undefined. Consumers are expected to use suitable `FromatVat*` functions