### PR TITLE
Skip coverage PR comment for Dependabot PRs

### DIFF
--- a/.github/workflows/buildntest.yml
+++ b/.github/workflows/buildntest.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Add Coverage PR Comment
         uses: marocchino/sticky-pull-request-comment@v3
-        if: (success() || failure()) && github.event_name == 'pull_request'
+        if: (success() || failure()) && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         with:
           hide_and_recreate: true
           hide_classify: "OUTDATED"


### PR DESCRIPTION
## Summary

- Dependabot PRs use a restricted `GITHUB_TOKEN` that cannot write PR comments
- The `marocchino/sticky-pull-request-comment` step was failing with `Resource not accessible by integration`
- Added `&& github.actor != 'dependabot[bot]'` to the step condition so it is skipped for Dependabot PRs

## Test plan

- [ ] Merge this PR — future Dependabot PRs should show a green build
- [ ] Verify the coverage comment still posts on regular PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)