### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -1,0 +1,14 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  automerge:
+    uses: Caspeco/github-actions/.github/workflows/dependabot-automerge.yml@v2
+    with:
+      automerge-level: 'minor'
+      automerge-level-dev: 'minor'
+      merge-method: 'squash'
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/automerge-dependabot.yml` using the shared `Caspeco/github-actions/.github/workflows/dependabot-automerge.yml@v2` reusable workflow, matching the config used by GiftCards/AccessManagement/SmsGateway (`automerge-level: minor`, `automerge-level-dev: minor`, `merge-method: squash`).
- VatValidation was the one repo without this workflow, so Dependabot PRs required manual merging.

## Test plan
- [x] Ran `dotnet test` — 479/480 passing; the one failure (`EnsureAndUpdateReadme`) is pre-existing and reproduces identically on `main`, unrelated to this change.
- [ ] Confirm a future Dependabot PR auto-merges as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)