### PR TITLE
Rename agents.md to AGENTS.md, use relative CLAUDE.md symlinks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # VatValidation
 
+Always check this directory for a README.md with details about the repo/project; if there isn't one, check the parent directory.
+
 VatValidation is a Caspeco library for validating VAT numbers and company registration numbers across European countries
 
 ## Code style

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-C:/Repos/VatValidation/agents.md
+AGENTS.md


### PR DESCRIPTION
## Summary
- Renamed `agents.md` → `AGENTS.md`
- Recreated `CLAUDE.md` as a relative symlink to `AGENTS.md` (previously an absolute path, which broke on machines where the repo lives at a different location)
- Added a note pointing agents at the nearest `README.md` for repo/project context

🤖 Generated with [Claude Code](https://claude.com/claude-code)